### PR TITLE
Added support for NAND devices

### DIFF
--- a/brict
+++ b/brict
@@ -210,7 +210,7 @@ bootloader_detect ()
 {
     if [ -f /boot/grub/grub.cfg ] || [ "$(command -v grub-install)" ]; then
         export BOOTLOADER="GRUB"
-    elif [ "$USE_DEVICETREE" ]; then
+    elif [ "$USE_DEVICETREE" ] || find /dev/ -iname "*ubi*" 2> /dev/null | grep -q .; then
         export BOOTLOADER="U-Boot"
     # Don't care about other bootloaders for now, only GRUB and U-Boot
     else

--- a/brict
+++ b/brict
@@ -199,7 +199,8 @@ devicetree_detect ()
     # fw_utils presennce does not guarantee U-Boot is used
     # GRUB seem to have some sort of support for device tree
     if  find /boot/ -name "*dtb" 2> /dev/null | grep -q . || \
-        find /var/rootdirs/mnt/boot/ -name "*dtb" 2> /dev/null | grep -q .; then
+        find /var/rootdirs/mnt/boot/ -name "*dtb" 2> /dev/null | grep -q . || \
+        find /dev/ -iname "*ubi*" 2> /dev/null | grep -q .; then
         export USE_DEVICETREE=1
     else
         export USE_DEVICETREE=""
@@ -210,7 +211,7 @@ bootloader_detect ()
 {
     if [ -f /boot/grub/grub.cfg ] || [ "$(command -v grub-install)" ]; then
         export BOOTLOADER="GRUB"
-    elif [ "$USE_DEVICETREE" ] || find /dev/ -iname "*ubi*" 2> /dev/null | grep -q .; then
+    elif [ "$USE_DEVICETREE" ]; then
         export BOOTLOADER="U-Boot"
     # Don't care about other bootloaders for now, only GRUB and U-Boot
     else


### PR DESCRIPTION
Searching for UBI inside /dev/ solves the problem for NAND devices. Tested here on Colibri iMX7D 512MB.